### PR TITLE
The method _converAllCharSeqToString assumes that all of the arguments ar

### DIFF
--- a/src/main/groovy/com/gmongo/internal/Patcher.groovy
+++ b/src/main/groovy/com/gmongo/internal/Patcher.groovy
@@ -67,12 +67,12 @@ class Patcher {
         convertedArgs[i] = _convert(args[i])
         continue
       }
-      _converAllCharSeqToString(args[i])
       if (!(args[i] instanceof Map) || (args[i] instanceof DBObject)) {
         convertedArgs[i] = args[i]
-        continue
+      } else {
+        _converAllCharSeqToString(args[i])
+        convertedArgs[i] = (args[i] as BasicDBObject)
       }
-      convertedArgs[i] = (args[i] as BasicDBObject)
     }
     return ((args instanceof List) ? convertedArgs : (convertedArgs as Object[]))
   }


### PR DESCRIPTION
The method _converAllCharSeqToString assumes that all of the arguments are Maps, so this makes it impossible to pass a WriteConcern to the insert methods. By pushing the call to that method after a type check, this allows WriteConcern to be passed in.
