### PR TITLE
2.7.3 mongo upgrade

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,5 @@
+* 0.9.6
+  - Upgraded to mongo-java-driver version 2.7.3
 * 0.9.4
   - Fix for #10 - null-safe operator in Patcher for null property values in map -> db object conversion (needed to work with Spock)
 * 0.9.3

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'eclipse'
 apply plugin: 'signing'
 
 group = 'com.gmongo'
-version = '0.9.5'
+version = '0.9.6'
 artifact = 'gmongo'
 
 bundleDir = "$buildDir/bundle"
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
   groovy group: 'org.codehaus.groovy', name: 'groovy', version: '1.8.5'
-  compile group: 'org.mongodb', name: 'mongo-java-driver', version: '2.7.2'
+  compile group: 'org.mongodb', name: 'mongo-java-driver', version: '2.7.3'
   testCompile group: 'junit', name: 'junit', version: '4.10'
 }
 


### PR DESCRIPTION
Mongo 2.7.x introduced a performance regression that 2.7.3 resolves. I updated the dependency, made sure tests pass, and modified the changelog to note the change.

http://inagist.com/mongodb/164795601467351040/
