### PR TITLE
proposed change of inheritance to match mongo client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
 apply plugin: 'signing'
+apply plugin: 'maven-publish'
 
-version = '1.4'
+group = 'com.gmongo'
+version = '1.5'
 
 project.ext {
   group = 'com.gmongo'
@@ -18,8 +20,13 @@ repositories {
 }
 
 dependencies {
+<<<<<<< HEAD
   compile group: 'org.codehaus.groovy', name: 'groovy', version: project.ext.groovyVersion
   compile group: 'org.codehaus.groovy', name: 'groovy-ant', version: project.ext.groovyVersion
+=======
+  groovy group: 'org.codehaus.groovy', name: 'groovy', version: project.ext.groovyVersion
+  groovy group: 'org.codehaus.groovy', name: 'groovy-ant', version: project.ext.groovyVersion
+>>>>>>> makign gmongoclient extend gmongo to fix grails mongodb plugin not workign with auth and 2.6+
   compile group: 'org.mongodb', name: 'mongo-java-driver', version: '2.13.0'
 
   testCompile group: 'org.codehaus.groovy', name: 'groovy-test', version: project.ext.groovyVersion

--- a/build.gradle
+++ b/build.gradle
@@ -20,13 +20,8 @@ repositories {
 }
 
 dependencies {
-<<<<<<< HEAD
   compile group: 'org.codehaus.groovy', name: 'groovy', version: project.ext.groovyVersion
   compile group: 'org.codehaus.groovy', name: 'groovy-ant', version: project.ext.groovyVersion
-=======
-  groovy group: 'org.codehaus.groovy', name: 'groovy', version: project.ext.groovyVersion
-  groovy group: 'org.codehaus.groovy', name: 'groovy-ant', version: project.ext.groovyVersion
->>>>>>> makign gmongoclient extend gmongo to fix grails mongodb plugin not workign with auth and 2.6+
   compile group: 'org.mongodb', name: 'mongo-java-driver', version: '2.13.0'
 
   testCompile group: 'org.codehaus.groovy', name: 'groovy-test', version: project.ext.groovyVersion

--- a/src/main/groovy/com/gmongo/GMongoClient.groovy
+++ b/src/main/groovy/com/gmongo/GMongoClient.groovy
@@ -26,69 +26,58 @@ import com.mongodb.DB
 
 import com.gmongo.internal.DBPatcher
 
-class GMongoClient {
-
-  @Delegate
-  MongoClient mongoClient;
+class GMongoClient extends GMongo {
 
   GMongoClient() {
-    this.mongoClient = new MongoClient(new ServerAddress())
+    this.mongo = new MongoClient(new ServerAddress())
   }
 
   GMongoClient(String host) {
-    this.mongoClient = new MongoClient(new ServerAddress(host))
+    this.mongo = new MongoClient(new ServerAddress(host))
   }
 
   GMongoClient(String host, MongoClientOptions options) {
-    this.mongoClient = new MongoClient(new ServerAddress(host), options)
+    this.mongo = new MongoClient(new ServerAddress(host), options)
   }
 
   GMongoClient(String host, int port) {
-    this.mongoClient = new MongoClient(new ServerAddress(host, port));
+    this.mongo = new MongoClient(new ServerAddress(host, port));
   }
 
   GMongoClient(ServerAddress addr) {
-    this.mongoClient = new MongoClient(addr, new MongoClientOptions.Builder().build());
+    this.mongo = new MongoClient(addr, new MongoClientOptions.Builder().build());
   }
 
   GMongoClient(ServerAddress addr, MongoClientOptions options) {
-    this.mongoClient = new MongoClient(addr, new MongoOptions(options));
+    this.mongo = new MongoClient(addr, new MongoOptions(options));
   }
 
   GMongoClient(List<ServerAddress> seeds) {
-    this.mongoClient = new MongoClient(seeds, new MongoClientOptions.Builder().build());
+    this.mongo = new MongoClient(seeds, new MongoClientOptions.Builder().build());
   }
 
   GMongoClient(List<ServerAddress> seeds, List<MongoCredential> credentialsList) {
-    this.mongoClient = new MongoClient(seeds, credentialsList);
+    this.mongo = new MongoClient(seeds, credentialsList);
   }
 
   GMongoClient(List<ServerAddress> seeds, List<MongoCredential> credentialsList, MongoClientOptions options) {
-    this.mongoClient = new MongoClient(seeds, credentialsList, options);
+    this.mongo = new MongoClient(seeds, credentialsList, options);
   }
 
   GMongoClient(List<ServerAddress> seeds, MongoClientOptions options) {
-    this.mongoClient = new MongoClient(seeds, new MongoOptions(options));
+    this.mongo = new MongoClient(seeds, new MongoOptions(options));
   }
 
   GMongoClient(MongoClientURI uri) {
-    this.mongoClient = new MongoClient(uri);
+    this.mongo = new MongoClient(uri);
   }
 
   GMongoClient(ServerAddress addr, List<MongoCredential> credentialsList) {
-    this.mongoClient = new MongoClient(addr, credentialsList);
+    this.mongo = new MongoClient(addr, credentialsList);
   }
 
   GMongoClient(ServerAddress addr, List<MongoCredential> credentialsList, MongoClientOptions options) {
-    this.mongoClient = new MongoClient(addr, credentialsList, options);
-  }
-
-  DB getDB(String name) {
-    patchAndReturn mongoClient.getDB(name)
-  }
-
-  static private patchAndReturn(db) {
-    DBPatcher.patch(db); return db
+    this.mongo = new MongoClient(addr, credentialsList, options);
   }
 
 }


### PR DESCRIPTION
Reference issue #29 
Proposed change to have GMongoClient extend GMongo - still keeping all constructors and delegating to the java driver, just using the parent class as the delegator.  GMongo constructors create Mongo client, GMongoClient constructor create a MongoClient. 
This allows the grails mongodb plugin to work with grails 2.6+ with auth enabled for driver 3.0.0 and greater.